### PR TITLE
Patch 1

### DIFF
--- a/lib/active_record/connection_adapters/master_slave_adapter.rb
+++ b/lib/active_record/connection_adapters/master_slave_adapter.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'active_record/connection_adapters/abstract/database_statements'
 require 'active_record/connection_adapters/abstract/schema_statements'
 

--- a/lib/master_slave_adapter.rb
+++ b/lib/master_slave_adapter.rb
@@ -1,6 +1,6 @@
 require 'active_record/connection_adapters/master_slave_adapter'
 
-require 'master_slave_adapter/active_record_extension'
+require 'master_slave_adapter/active_record_extensions'
 require 'master_slave_adapter/adapter'
 require 'master_slave_adapter/instance_methods_generation'
 

--- a/lib/master_slave_adapter.rb
+++ b/lib/master_slave_adapter.rb
@@ -1,7 +1,5 @@
 require 'active_record/connection_adapters/master_slave_adapter'
 
-require 'master_slave_adapter/active_record_extensions'
-require 'master_slave_adapter/adapter'
-require 'master_slave_adapter/instance_methods_generation'
-
-require 'master_slave_adapter/version'
+module MasterSlaveAdapter
+  autoload :Version, 'master_slave_adapter/version'
+end

--- a/lib/master_slave_adapter/active_record_extensions.rb
+++ b/lib/master_slave_adapter/active_record_extensions.rb
@@ -11,7 +11,7 @@ ActiveRecord::Base.class_eval do
       if connection.respond_to? :with_master
         connection.with_master(&block)
       else
-        raise "no with_master"
+        yield
       end
     end
 
@@ -24,7 +24,7 @@ ActiveRecord::Base.class_eval do
       if connection.respond_to? :with_slave
         connection.with_slave(&block)
       else
-        raise "no with_slave"
+        yield
       end
     end
 
@@ -39,7 +39,7 @@ ActiveRecord::Base.class_eval do
       if connection.respond_to? :with_consistency
         connection.with_consistency(clock, &block)
       else
-        raise "no with_consistency"
+        yield
       end
     end
 


### PR DESCRIPTION
- fixes loading of master_slave_adapter (typo in require statement)
- allows usage of `ActiveRecord::Base.with_*` methods in case master_slave_adapter is not used/configured. This could be the case in Rails development environment.
- reduces usage of `require`  
